### PR TITLE
Plug interpolation

### DIFF
--- a/partons/examples/interp.rs
+++ b/partons/examples/interp.rs
@@ -1,5 +1,6 @@
 // Load configs and download index file
 use anyhow::Result;
+use ndarray::array;
 use partons::configs::Configs;
 
 fn main() -> Result<()> {
@@ -16,7 +17,15 @@ fn main() -> Result<()> {
         let mut set = source.set(&header)?;
         println!("{set:#?}");
         let grid0 = set.member(0)?;
-        println!("{grid0}");
+        let val = grid0
+            .evaluate(
+                &vec![1, 1],
+                &vec![0.1, 0.2],
+                &vec![10., 10.],
+                &vec![4, 4, 5],
+            )
+            .unwrap();
+        println!("{val:?}");
     }
 
     Ok(())

--- a/partons/examples/interp.rs
+++ b/partons/examples/interp.rs
@@ -1,0 +1,23 @@
+// Load configs and download index file
+use anyhow::Result;
+use partons::configs::Configs;
+
+fn main() -> Result<()> {
+    let cfg = Configs::load()?;
+
+    let mut source = cfg.sources[0].clone();
+    source.register_cache(cfg.data_path()?);
+    let index = source.index()?;
+
+    // display the first element, if non-empty
+    for set in ["NNPDF40_nnlo_as_01180"] {
+        //, "MSHT20nnlo_as118", "CT18NNLO"] {
+        let header = index.get(set)?;
+        let mut set = source.set(&header)?;
+        println!("{set:#?}");
+        let grid0 = set.member(0)?;
+        println!("{grid0}");
+    }
+
+    Ok(())
+}

--- a/partons/src/block.rs
+++ b/partons/src/block.rs
@@ -1,68 +1,29 @@
 //! Interpolation block
-use std::collections::HashMap;
-
-use anyhow::{anyhow, Result};
-use ndarray::{Array1, Array3};
+use anyhow::Result;
+use ndarray::{Array1, Array2};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Block {
-    pub pids: Array1<i32>,
-    pub xgrid: Array1<f64>,
-    pub mu2grid: Array1<f64>,
-    pub(crate) values: Array3<f64>,
-    pid_map: HashMap<i32, usize>,
+pub struct Block1 {
+    pub coords: Array1<f64>,
+    pub(crate) values: Array1<f64>,
 }
 
-impl Block {
-    pub(crate) fn new(
-        pids: Array1<i32>,
-        xgrid: Array1<f64>,
-        mu2grid: Array1<f64>,
-        values: Array3<f64>,
-    ) -> Self {
-        assert_eq!(values.shape(), &[pids.len(), xgrid.len(), mu2grid.len()]);
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Block2 {
+    pub coords: (Array1<f64>, Array1<f64>),
+    pub(crate) values: Array2<f64>,
+}
 
-        let pid_map = pids.iter().enumerate().map(|(i, v)| (*v, i)).collect();
+impl Block2 {
+    pub(crate) fn new(coords: (Array1<f64>, Array1<f64>), values: Array2<f64>) -> Self {
+        assert_eq!(values.shape(), &[coords.0.len(), coords.1.len()]);
 
-        Self {
-            pids,
-            xgrid,
-            mu2grid,
-            values,
-            pid_map,
-        }
-    }
-
-    pub(crate) fn pid_index(&self, pid: i32) -> Result<usize> {
-        self.pid_map
-            .get(&pid)
-            .ok_or(anyhow!("PID '{}' not found", pid))
-            .map(|idx| *idx)
+        Self { coords, values }
     }
 
     // TODO: delegate interpolation to ndinterp
-    pub(crate) fn interp(&self, pid: i32, x: f64, mu2: f64) -> Result<f64> {
-        // determine interpolation slice
-        let slice = self.pid_index(pid)?;
-
-        let idx = self
-            .xgrid
-            .iter()
-            .enumerate()
-            .filter(|(_, y)| y > &&x)
-            .next()
-            .unwrap()
-            .0;
-        let idmu = self
-            .mu2grid
-            .iter()
-            .enumerate()
-            .filter(|(_, nu2)| nu2 > &&mu2)
-            .next()
-            .unwrap()
-            .0;
-
-        return Ok(self.values[[slice, idx, idmu]]);
+    pub(crate) fn interp(&self, x1: f64, x2: f64) -> Result<f64> {
+        return Ok(self.values[[0, 0]]);
     }
 }

--- a/partons/src/block.rs
+++ b/partons/src/block.rs
@@ -9,6 +9,19 @@ pub struct Block1 {
     pub(crate) values: Array1<f64>,
 }
 
+impl Block1 {
+    pub(crate) fn new(coords: Array1<f64>, values: Array1<f64>) -> Self {
+        assert_eq!(values.shape(), coords.shape());
+
+        Self { coords, values }
+    }
+
+    // TODO: delegate interpolation to ndinterp
+    pub(crate) fn interp(&self, x: f64) -> Result<f64> {
+        return Ok(self.values[[0]]);
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Block2 {
     pub coords: (Array1<f64>, Array1<f64>),

--- a/partons/src/member.rs
+++ b/partons/src/member.rs
@@ -9,18 +9,18 @@ use bytes::Bytes;
 use ndarray::Array1;
 use serde::{Deserialize, Serialize};
 
-use crate::block::Block;
+use crate::block::Block2;
 
 pub(crate) type Metadata = HashMap<String, String>;
 
 /// Member of a set
 ///
 /// This contains the whole member data, including the interpolation
-/// [`Block`](crate::block::Block)s and further optional metadata.
+/// [blocks](crate::block::Block2) and further optional metadata.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Member {
     pub(crate) metadata: Metadata,
-    pub(crate) blocks: Vec<Block>,
+    pub(crate) blocks: Vec<Block2>,
 }
 
 #[derive(Decode, Encode)]
@@ -49,7 +49,7 @@ impl Member {
         }
 
         let mut values: Array1<f64> = Array1::zeros(x.raw_dim());
-        values[0] = self.blocks[(nf[0] - 3) as usize].interp(pid[0], x[0], mu2[0])?;
+        values[0] = self.blocks[(nf[0] - 3) as usize].interp(x[0], mu2[0])?;
 
         Ok(values)
     }


### PR DESCRIPTION
The main goal is to finally attach interpolation, especially for the PDFs themselves ($\alpha_s$ is slightly less relevant) such that we could start using partons, at least with an alpha pre-release.

As soon as I started, I realized I was doing something rather unnecessary. Indeed, I already divided in two separate structures the member of a set and the block related to the PDF to be interpolated. Moreover, a member already contains multiple blocks, because of the multiple values of `nf`. However, the handling of the PID should be no different from `nf`, so, instead of doing the work once more, I decided to rework the block to be exactly the interpolation unit, and handle the discrete indices all in one place